### PR TITLE
sidebar menu content hover effect fixed

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -209,8 +209,9 @@ aside a:hover {
   backdrop-filter: blur(18.5px);
   -webkit-backdrop-filter: blur(18.5px);
 
-  border-top-left-radius: 10px;
-  border-bottom-left-radius: 10px;
+  border-top-right-radius: 25px;
+  border-bottom-right-radius: 25px;
+  margin-right: 20px;
   border: 1px solid rgba(255, 255, 255, 0.18);
 
   /* 
@@ -219,8 +220,8 @@ aside a:hover {
   outline: none;
   position: relative;
   /* background-color: #fff; */
-  border-top-left-radius: 20px;
-  border-bottom-left-radius: 20px;
+  border-top-left-radius: 25px;
+  border-bottom-left-radius: 25px;
 }
 
 .delete{


### PR DESCRIPTION

![WhatsApp Image 2024-05-22 at 09 56 05_5cc5956d](https://github.com/Satyam1923/Spring-Music-Player/assets/137780818/f749cd84-836f-4c9f-957d-0d3920048c13)
This is my fix 
### Description
When we hover on sidebar menu contents a box appears around each content from right side it does not have a proper margin and proper border radius which makes UI of the website unimpressive. 

### Changes
List the detailed changes made in this PR.
I have made changes in CSS. Set margin-right and set border-radius also
### Testing Instructions
Detailed instructions on how to test the changes. Include any setup needed and specific test cases.
1. Pull this branch.
2. Run `npm install` to install dependencies.
3. Run `npm test` to execute the test suite.
4. Verify that ...

### Checklist
Make sure to check off all the items before submitting. Mark with [x] if done.
- [X ] I have performed a self-review of my code
- [X ] I have commented my code, particularly in hard-to-understand areas
- [X ] My changes generate no new warnings
- [X ] I am working on this issue under GSSOC
