### PR TITLE
added workflow for closing old PRs

### DIFF
--- a/.github/workflows/close-old-pr.yml
+++ b/.github/workflows/close-old-pr.yml
@@ -1,0 +1,34 @@
+name: Close Stale PRs
+
+on:
+  schedule:
+    - cron: '0 0 * * *' # Runs daily at midnight
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+
+permissions:
+  pull-requests: write
+  issues: write
+
+jobs:
+  close_stale_prs:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+  
+    steps:
+    - uses: actions/stale@v7
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-pr-message: 'This PR has been automatically closed due to inactivity from the owner for 15 days.'
+        days-before-pr-stale: 15
+        days-before-pr-close: 0
+        exempt-pr-author: false
+        exempt-pr-labels: ''
+        only-labels: ''
+        operations-per-run: 30
+        remove-stale-when-updated: true
+        debug-only: false


### PR DESCRIPTION
### Description
This feature aims to automate the management of open PRs in a repository, ensuring that outdated or abandoned PRs are closed in a timely manner. By doing so, it helps maintain repository hygiene, improves workflow efficiency, and provides a better experience for both maintainers and contributors.

### Related Issues

Fixes #168 

### Changes
 Added a new feature to close old PRs

### Checklist
Make sure to check off all the items before submitting. Mark with [x] if done.
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] I am working on this issue under GSSOC
